### PR TITLE
Add: library.json for PlatformIO library registry

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,0 +1,23 @@
+{
+  "name": "arduino-rgb-led",
+  "keywords": "arduino, rgb, led",
+  "description": "A tiny lib to animate a RGB led in arduino programs",
+  "repository":
+  {
+    "type": "git",
+    "url": "https://github.com/hakkanicko/arduino-rgb-led"
+  },
+  "authors":
+  [
+    {
+      "name": "hakkanicko",
+      "email": "???? optional",
+      "url": "??? optional",
+      "maintainer": true
+    }
+  ],
+  "version": "1.0",
+  "frameworks": "arduino",
+  "platforms": "*"
+}
+


### PR DESCRIPTION
Here is the library.json file to declare your lib to the PlatformIO registry.
You should update the email, website and other fields to your needs.

The repository must be public for the PlatformIO Library Registry Crawler access.

When you're ready, execute this command:
```
platformio lib register https://raw.githubusercontent.com/hakkanicko/arduino-rgb-led/master/library.json
```

If you want to publish to the Arduino library as well, this file should changed to a `.properties` format (https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification)